### PR TITLE
Hotfix - Esconder páginas de gerenciamento

### DIFF
--- a/src/Components/Header/index.tsx
+++ b/src/Components/Header/index.tsx
@@ -24,17 +24,14 @@ const Header: React.FC = () => {
         </Navbar.Brand>
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
-          <Nav style={{ width: "100%", justifyContent: "space-around" }}>
-            <Nav.Link>
-              <MyLink to={"/"}>Início</MyLink>
-            </Nav.Link>
-            <Nav.Link>
+          <Nav style={{ width: "100%" }} className="justify-content-md-end">
+            {/* <Nav.Link>
               <MyLink to={"/"}>Pesquisa Avançada</MyLink>
-            </Nav.Link>
+            </Nav.Link> */}
             <Nav.Link>
               <MyLink to={"/sobre-nos"}>Sobre Nós</MyLink>
             </Nav.Link>
-            <MyLink to={""}>
+            {/* <MyLink to={""}>
               <CustomNavDropdown title="Gerenciamento" id="management-nav-dropdown">
                 <CustomNavDropdown.Item>
                   <HeaderButton>
@@ -47,7 +44,7 @@ const Header: React.FC = () => {
                   </HeaderButton>
                 </CustomNavDropdown.Item>
               </CustomNavDropdown>
-            </MyLink>
+            </MyLink> */}
           </Nav>
         </Navbar.Collapse>
       </Container>

--- a/src/Components/ResultCard/styles.ts
+++ b/src/Components/ResultCard/styles.ts
@@ -9,16 +9,11 @@ export const Container = styled.div`
 
   background-color: #172a3a;
 
-  width: 80%;
+  width: 100%;
   padding: 1%;
 
   margin-top: 0.7rem;
   border-radius: 10px;
-
-  @media screen and (max-width: 1024px) {
-    width: 100%;
-    padding: 2%;
-  }
 
   &:hover {
     cursor: pointer;

--- a/src/Components/SearchBar/styles.ts
+++ b/src/Components/SearchBar/styles.ts
@@ -8,7 +8,7 @@ export const Container = styled.div`
   align-items: center;
   justify-content: space-evenly;
 
-  width: 80%;
+  width: 100%;
   margin-top: 1rem;
   margin-bottom: 1rem;
   padding-left: 0.5rem;

--- a/src/Pages/Admin/index.tsx
+++ b/src/Pages/Admin/index.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
+
 import Header from "../../Components/Header";
 import Footer from "../../Components/Footer";
-
-import { Container, Title } from "./styles";
+import { Container, Title, AdminItemCard, MyLink } from "./styles";
 import { Card, CardGroup, Col, Row } from "react-bootstrap";
 
 const AdminPage: React.FC = () => {
@@ -17,26 +17,29 @@ const AdminPage: React.FC = () => {
       <CardGroup>
         <Row className="g-2">
           <Col md={3}>
-            <Card>
-              <Card.Body>
-                <Card.Title>Fontes</Card.Title>
-                <Card.Text>
-                  Gerenciamento de expressões e palavras chaves que são
-                  utilizadas para extração de dados das fontes.
-                </Card.Text>
-              </Card.Body>
-            </Card>
+            <MyLink to="/fontes">
+              <AdminItemCard>
+                <Card.Body>
+                  <Card.Title>Fontes</Card.Title>
+                  <Card.Text>
+                    Websites utilizados como fonte de conteúdo.
+                  </Card.Text>
+                </Card.Body>
+              </AdminItemCard>
+            </MyLink>
           </Col>
           <Col md={3}>
-            <Card>
-              <Card.Body>
-                <Card.Title>Expressões</Card.Title>
-                <Card.Text>
-                  Gerenciamento de expressões e palavras chaves que são
-                  utilizadas para extração de dados das fontes.
-                </Card.Text>
-              </Card.Body>
-            </Card>
+            <MyLink to="/expressoes">
+              <AdminItemCard>
+                <Card.Body>
+                  <Card.Title>Expressões</Card.Title>
+                  <Card.Text>
+                    Expressões e palavras chaves que são utilizadas para
+                    extração de dados das fontes.
+                  </Card.Text>
+                </Card.Body>
+              </AdminItemCard>
+            </MyLink>
           </Col>
         </Row>
       </CardGroup>

--- a/src/Pages/Admin/index.tsx
+++ b/src/Pages/Admin/index.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from "react";
+import Header from "../../Components/Header";
+import Footer from "../../Components/Footer";
+
+import { Container, Title } from "./styles";
+import { Card, CardGroup, Col, Row } from "react-bootstrap";
+
+const AdminPage: React.FC = () => {
+  useEffect(() => {
+    document.title = "PCTs - Admin";
+  }, []);
+
+  return (
+    <Container>
+      <Header />
+      <Title>Gerenciamento de Conteúdo</Title>
+      <CardGroup>
+        <Row className="g-2">
+          <Col md={3}>
+            <Card>
+              <Card.Body>
+                <Card.Title>Fontes</Card.Title>
+                <Card.Text>
+                  Gerenciamento de expressões e palavras chaves que são
+                  utilizadas para extração de dados das fontes.
+                </Card.Text>
+              </Card.Body>
+            </Card>
+          </Col>
+          <Col md={3}>
+            <Card>
+              <Card.Body>
+                <Card.Title>Expressões</Card.Title>
+                <Card.Text>
+                  Gerenciamento de expressões e palavras chaves que são
+                  utilizadas para extração de dados das fontes.
+                </Card.Text>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      </CardGroup>
+      <Footer />
+    </Container>
+  );
+};
+
+export default AdminPage;

--- a/src/Pages/Admin/styles.ts
+++ b/src/Pages/Admin/styles.ts
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+
+  position: relative;
+`;
+
+export const Title = styled.p`
+  flex: 1;
+  margin-bottom: 5vh;
+  align-self: center;
+
+  color: #004346;
+  font-size: 2rem;
+  font-weight: bold;
+  font-style: normal;
+  line-height: 1.5rem;
+  font-family: Rokkitt, sans-serif;
+
+  @media screen and (max-width: 1024px) {
+    margin-left: 5%;
+  }
+`;

--- a/src/Pages/Admin/styles.ts
+++ b/src/Pages/Admin/styles.ts
@@ -1,4 +1,6 @@
 import styled from "styled-components";
+import { Card } from "react-bootstrap";
+import { Link } from "react-router-dom";
 
 export const Container = styled.div`
   flex: 1;
@@ -25,3 +27,16 @@ export const Title = styled.p`
     margin-left: 5%;
   }
 `;
+
+export const AdminItemCard = styled(Card)`
+ height: 100%;
+ cursor: pointer;
+`;
+
+export const MyLink = styled(Link)`
+  color: #1bc47d;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+`;
+

--- a/src/Pages/HomeScreen/index.tsx
+++ b/src/Pages/HomeScreen/index.tsx
@@ -12,6 +12,7 @@ import {
   Container,
   MyFlatlist,
   NewResultsContainer,
+  SearchAreaContainer,
   NewsTitle,
 } from "./styles";
 
@@ -40,7 +41,6 @@ const HomeScreen: React.FC = () => {
     useState<documentsResponse>();
   const [isLoading, setIsLoading] = useState(false);
   const [mySearch, setMySearch] = useState("");
-
 
   useEffect(() => {
     document.title = "PCTs";
@@ -88,15 +88,17 @@ const HomeScreen: React.FC = () => {
     <Container>
       <Header />
       <MyCarousel />
-      <SearchBar
-        ableToSearch={mySearch === "" ? false : true}
-        searchTerm={mySearch}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          setMySearch(e.target.value);
-        }}
-      />
-      <NewsTitle>Últimas Atualizações</NewsTitle>
       <NewResultsContainer>
+        <SearchAreaContainer>
+          <SearchBar
+            ableToSearch={mySearch === "" ? false : true}
+            searchTerm={mySearch}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setMySearch(e.target.value);
+            }}
+          />
+        </SearchAreaContainer>
+        <NewsTitle>Últimas Atualizações</NewsTitle>
         {isLoading === true ? (
           <Loader
             type="ThreeDots"

--- a/src/Pages/HomeScreen/styles.ts
+++ b/src/Pages/HomeScreen/styles.ts
@@ -10,30 +10,48 @@ export const Container = styled.div`
   position: relative;
 `;
 
+export const SearchAreaContainer = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  
+  width: 60%;
+  
+  overflow: auto;
+  overflow-x: hidden;
+  
+  margin-bottom: 1rem;
+  
+  @media screen and (max-width: 640px) {
+    width: 100%;
+    padding: 2%;
+  }
+`;
+
 export const NewResultsContainer = styled.div`
   flex: 1;
   display: flex;
   align-items: center;
   flex-direction: column;
   justify-content: center;
-
-  width: 90%;
-  /* padding-top: 20%; */
-  /* max-height: 50vh; */
-
+  
+  width: 80%;
+  
   overflow: auto;
   overflow-x: hidden;
-
+  
   margin-bottom: 1rem;
-
-  /* @media screen and (max-width: 1024px) {
-    max-height: 45vh;
-  } */
+  
+  @media screen and (max-width: 1024px) {
+    width: 100%;
+    padding: 2%;
+  }
 `;
 
 export const NewsTitle = styled.p`
   flex: 1;
-  margin-left: 10%;
   margin-bottom: 0.2%;
   align-self: flex-start;
 

--- a/src/Pages/Monitoring/index.tsx
+++ b/src/Pages/Monitoring/index.tsx
@@ -71,6 +71,7 @@ const Monitoring: React.FC = () => {
   const [sourceID] = useState(params.sourceID);
 
   useEffect(() => {
+    document.title = "Monitoramento";
     getCrawlersExecutions();
     getCrawlerDetail();
   }, []);

--- a/src/Pages/Results/index.tsx
+++ b/src/Pages/Results/index.tsx
@@ -9,10 +9,14 @@ import ResultCard from "../../Components/ResultCard";
 import Flatlist from "flatlist-react";
 import Loader from "react-loader-spinner";
 
-import { Container as PageContainer, NewResultsContainer } from "./styles";
+import {
+  Container as PageContainer,
+  NewResultsContainer,
+  SearchAreaContainer,
+} from "./styles";
 import { api, apiCrawlers } from "../../services/api";
 import { useRouteMatch } from "react-router";
-import { Form, Row, Col } from "react-bootstrap";
+import { Row, Col } from "react-bootstrap";
 
 import SelectFilter from "../../Components/SelectFilter";
 import DateFilterModal from "../../Components/DateFilterModal";
@@ -228,7 +232,8 @@ const Results: React.FC = () => {
       />
       <NewResultsContainer>
         <h2 className="results-title">Resultados</h2>
-        <Row style={{ width: "80%", marginBottom: "20px" }}>
+        {/* <Row style={{ width: "80%", marginBottom: "20px" }}> */}
+        <SearchAreaContainer>
           <SearchBar
             ableToSearch={searchTerm === "" ? false : true}
             searchTerm={searchTerm}
@@ -236,7 +241,7 @@ const Results: React.FC = () => {
               setSearchTerm(e.target.value);
             }}
           />
-          <Row className="justify-content-md-left">
+          <Row className="justify-content-md-start" style={{ width: "100%" }}>
             <Col sm lg="2" style={{ padding: "0px", paddingRight: "0.5vh" }}>
               <SelectFilter
                 items={availableSources}
@@ -265,7 +270,8 @@ const Results: React.FC = () => {
               />
             </Col>
           </Row>
-        </Row>
+        </SearchAreaContainer>
+        {/* </Row> */}
 
         {isLoading === true ? (
           <Loader type="ThreeDots" color="#004346" height={50} width={50} />

--- a/src/Pages/Results/styles.ts
+++ b/src/Pages/Results/styles.ts
@@ -9,6 +9,26 @@ export const Container = styled.div`
   position: relative;
 `;
 
+export const SearchAreaContainer = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  
+  width: 80%;
+  
+  overflow: auto;
+  overflow-x: hidden;
+  
+  margin-bottom: 1rem;
+  
+  @media screen and (max-width: 1024px) {
+    width: 100%;
+    padding: 2%;
+  }
+`;
+
 export const NewResultsContainer = styled.div`
   flex: 1;
   width: 90%;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Switch, Route } from "react-router-dom";
 
+import Admin from "../Pages/Admin";
 import HomeScreen from "../Pages/HomeScreen";
 import AboutUs from "../Pages/AboutUs";
 import Results from "../Pages/Results";
@@ -11,6 +12,7 @@ import Sources from "../Pages/Sources";
 const Routes: React.FC = () => (
     <Switch>
     <Route path="/" exact component={HomeScreen} />
+    <Route path="/admin" exact component={Admin} />
     <Route path="/sobre-nos" exact component={AboutUs} />
     <Route path="/resultados/:searchTerm+" component={Results} />
     <Route path="/fontes/:sourceID/monitoramento" exact component={Monitoring} />


### PR DESCRIPTION
* Agora as páginas de gerenciamento das expressões-chave e das fontes de dados não ficam mais visíveis no menu, é necessário acessar o endpoint "/admin".